### PR TITLE
KING-830: Adds ability to migrate DB Tables without Data

### DIFF
--- a/bin/sequel
+++ b/bin/sequel
@@ -6,6 +6,7 @@ require 'optparse'
 
 code = nil
 copy_databases = nil
+copy_database_schema = nil
 dump_migration = nil
 dump_schema = nil
 env = nil
@@ -44,6 +45,11 @@ options = OptionParser.new do |opts|
   opts.on("-C", "--copy-databases", "copy one database to another") do 
     copy_databases = true
     exclusive_options << :C
+  end
+
+  opts.on("-CS", "--copy-database-schema", "Migrates database schema only. No Data.") do
+    copy_database_schema = true
+    exclusive_options << :CS
   end
   
   opts.on("-d", "--dump-migration", "print database migration to STDOUT") do 
@@ -230,6 +236,43 @@ begin
       puts "Primary key sequences reset successfully"
     end
     puts "Database copy finished in #{Time.now - start_time} seconds"
+    exit
+  end
+  if copy_database_schema
+    Sequel.extension :migration
+    DB.extension :schema_dumper
+
+    db2 = ARGV.shift
+    error_proc["Error: Must specify database connection string or path to yaml file as second argument for database you want to copy to"] if db2.nil? || db2.empty?
+    extra_proc.call
+    start_time = Time.now
+    TO_DB = connect_proc[db2]
+    same_db = DB.database_type==TO_DB.database_type
+    index_opts = {:same_db=>same_db}
+    index_opts[:index_names] = :namespace if !DB.global_index_namespace? && TO_DB.global_index_namespace?
+
+    puts "Databases connections successful"
+    schema_migration = eval(DB.dump_schema_migration(:indexes=>false, :same_db=>same_db))
+    index_migration = eval(DB.dump_indexes_migration(index_opts))
+    fk_migration = eval(DB.dump_foreign_key_migration(:same_db=>same_db))
+    puts "Migrations dumped successfully"
+
+    schema_migration.apply(TO_DB, :up)
+    puts "Tables created"
+
+    puts "Begin creating indexes"
+    index_migration.apply(TO_DB, :up)
+    puts "Finished creating indexes"
+
+    puts "Begin adding foreign key constraints"
+    fk_migration.apply(TO_DB, :up)
+    puts "Finished adding foreign key constraints"
+
+    if TO_DB.database_type == :postgres
+      TO_DB.tables.each{|t| TO_DB.reset_primary_key_sequence(t)}
+      puts "Primary key sequences reset successfully"
+    end
+    puts "Database Schema Migration finished in #{Time.now - start_time} seconds"
     exit
   end
   if code


### PR DESCRIPTION
- Modify bin/sequel script
- Used "copy_databases" routine as a starting point and removed table data copying aspect for copy_database_schema routine